### PR TITLE
refactor: clean up icon import

### DIFF
--- a/frontend/src/asset/img/index.js
+++ b/frontend/src/asset/img/index.js
@@ -1,0 +1,29 @@
+import logo from './logo.PNG';
+import menuExpandIcon from './menu_expand.png';
+import homeIcon from './home_icon.PNG';
+import menuIcon from './menu_icon.png';
+import partiesIcon from './parties_icon.png';
+import businessIcon from './business_meetings.png';
+import cateringIcon from './catering_icon.png';
+import contactIcon from './contact_icon.png';
+import hoursIcon from './hours_icon.png';
+import phoneIcon from './phone_icon.png';
+import peopleDining from './people_dining.png';
+import imgBehind from './img_behind.png';
+import map from './map.png'
+
+export {
+  logo,
+  menuExpandIcon,
+  homeIcon,
+  menuIcon,
+  partiesIcon,
+  businessIcon,
+  cateringIcon,
+  contactIcon,
+  hoursIcon,
+  phoneIcon,
+  peopleDining,
+  imgBehind,
+  map
+}

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,18 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-// import Button from './Button';
-import logo from '../asset/img/logo.PNG';
-import menuExpandIcon from '../asset/img/menu_expand.png';
-import homeIcon from '../asset/img/home_icon.PNG';
-import menuIcon from '../asset/img/menu_icon.png';
-import partiesIcon from '../asset/img/parties_icon.png';
-import businessIcon from '../asset/img/business_meetings.png';
-import cateringIcon from '../asset/img/catering_icon.png';
-import contactIcon from '../asset/img/contact_icon.png';
-import hoursIcon from '../asset/img/hours_icon.png';
-import phoneIcon from '../asset/img/phone_icon.png';
-import peopleDining from '../asset/img/people_dining.png';
-import imgBehind from '../asset/img/img_behind.png';
+import Button from './elements/Button';
+import { logo, menuExpandIcon, homeIcon, menuIcon, partiesIcon, businessIcon, cateringIcon, contactIcon, hoursIcon, phoneIcon, peopleDining, imgBehind} from '../asset/img';
 
 import { color } from '../util';
 


### PR DESCRIPTION
Safi should approve or reject this pull request.

Use an index.js file to simplify the import of icons. 

The "material-ui" video that Luciano shared uses this pattern with an index.js file to import multiple files. [video](https://youtu.be/xm4LX5fJKZ8?t=734)